### PR TITLE
Create new Ink app in a new directory

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,19 +1,46 @@
 #!/usr/bin/env node
 'use strict';
+const path = require('path');
 const meow = require('meow');
 const createInkApp = require('.');
 
-meow(`
+const cli = meow(
+	`
 	Options
 		--typescript		Use TypeScript React template
 
 	Usage
-		$ mkdir my-cli
-		$ cd my-cli
-	  $ create-ink-app
-`);
+		$ create-ink-app <project-directory>
 
-createInkApp().catch(error => {
-	console.error(error.stack);
-	process.exit(1);
-});
+	Examples
+		$ create-ink-app my-cli
+		$ create-ink-app .
+`,
+	{
+		flags: {
+			typescript: {
+				type: 'boolean'
+			}
+		}
+	}
+);
+
+const projectDirectoryPath = path.resolve(process.cwd(), cli.input[0] || '.');
+
+createInkApp(projectDirectoryPath)
+	.catch(error => {
+		console.error(error.stack);
+		process.exit(1);
+	})
+	.then(() => {
+		const pkgName = path.basename(projectDirectoryPath);
+		const relativePath = path.relative(process.cwd(), projectDirectoryPath);
+
+		console.log();
+		console.log('Ink app created! Get started with:');
+		console.log();
+		if (relativePath) {
+			console.log(`  cd ${relativePath}`);
+		}
+		console.log(`  ${pkgName}`);
+	});

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,9 @@
 This helper tool scaffolds out basic project structure for Ink apps and lets you avoid the boilerplate and get to building beautiful CLIs in no time.
 
 ```bash
-$ mkdir my-fancy-cli
-$ cd my-fancy-cli
-$ npx create-ink-app
+$ npx create-ink-app my-fancy-cli
 # Or create with TypeScript React
-$ npx create-ink-app --typescript
+$ npx create-ink-app --typescript my-fancy-ts-cli
 ```
 
 ![](media/demo.gif)


### PR DESCRIPTION
Close #1.

Added support to pass a new input `<project-directory>` indicating where the project should be scaffolded in. Currently the input is optional, the current directory will be the default if it's not present, so that we can make this feature backward-compatible. In the future, we should at least add a warning if the input is not passed.

I also added some basic helpful message upon successfully created an app. Wordings are TBD.

**Example**:

```bash
create-ink-app # Create an Ink app in the current working directory
create-ink-app . # Same as above
create-ink-app my-cli # Create an Ink app in the "my-cli" directory relative to the current working directory
create-ink-app --typescript my-cli # Typescript template also works
```

I intentionally move some logic to `cli.js` so that in the future we can support programmatic API by directly importing `index.js` as well.