### PR TITLE
Mark `dist/cli.js` executable

### DIFF
--- a/templates/ts/_package.json
+++ b/templates/ts/_package.json
@@ -7,7 +7,7 @@
 		"node": ">=10"
 	},
 	"scripts": {
-		"build": "tsc",
+		"build": "tsc && chmod +x dist/cli.js",
 		"start": "npm run build && dist/cli.js",
 		"pretest": "npm run build",
 		"test": "xo && ava"


### PR DESCRIPTION
Fixes #17
Fixes #21

Since this `dist/cli.js` is compiled from TypeScript, we should mark the `dist/cli.js` file executable manually.